### PR TITLE
Update authorization to use OAuth Client Credentials flow.

### DIFF
--- a/AprimoHotFolderService/Aprimo.HotFolderService.ps1
+++ b/AprimoHotFolderService/Aprimo.HotFolderService.ps1
@@ -60,7 +60,7 @@ process {
     if(($PSBoundParameters.ContainsKey('MetaDataFile') -and -not($PSBoundParameters.ContainsKey('MetaDataSchemaName')))){
         Write-InfoLog "When uploading a metadata file both parameters MetaDataFile and MetaDataSchemaName are required."
         return
-    } 
+    }
 
     [hashtable]$entries = Get-FileList -Path $Path -FailedFilesFolder $FailedFilesFolder
 
@@ -95,7 +95,7 @@ process {
         if ($ClassifySubFolders) {
             $subClassifications = $subFoldersStr.Split('\\', [System.StringSplitOptions]::RemoveEmptyEntries)
         }
-        
+
         if (-not (Test-Path -LiteralPath $entry.Key)) {
             continue
         }
@@ -107,10 +107,10 @@ process {
 
         $isFileLocked = $false
         try {
-            
+
             $oFile = New-Object System.IO.FileInfo $entry.Key
             $oStream = $oFile.Open([System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
-                    
+
             if ($oStream) {
                 $oStream.Close()
             }
@@ -133,10 +133,10 @@ process {
         [System.Diagnostics.Stopwatch]$sw = [System.Diagnostics.Stopwatch]::StartNew()
 
         try {
-            
+
             $metadataTokenToUse = ""
             $metadataFileToUse = ""
-            
+
             # When metadata file is passed as param this is always leading
             if($MetaDataFile){
                 $metadataFileToUse = $MetaDataFile
@@ -147,10 +147,10 @@ process {
                 # Do not use the attached metadata file when a global metadata file is used.
                 if($MetaDataFile){
                     Write-WarningLog "Skip metadata file '$($entry.Key)'. Another metadata file is passed to the commandline"
-                    
+
                     # can be (re)moved already by a previous file
                     if(Test-Path($entry.Value)){
-                        
+
                         AddToFailedFolder -Path $entry.Value -FailedFilesFolder $FailedFilesFolder -SubFolders $subFoldersStr
                     }
                 }
@@ -165,7 +165,7 @@ process {
                     $metadataFileToUse = $entry.Value
                     $metadataTokenToUse = $metaDataFileUploadTokens.Item($entry.Value)
                 }
-                
+
             }
             $message = "Start upload file: $filePath."
             if($metadataFileToUse -and $MetaDataSchemaName){
@@ -185,7 +185,7 @@ process {
             Write-ErrorLog "An error occurred while creating a new record for $($entry.Key)`n`n $errorMsg"
 
             AddToFailedFolder -Path $entry.Key -FailedFilesFolder $FailedFilesFolder -SubFolders $subFoldersStr
-            
+
             $totalFailed++
         }
 
@@ -204,12 +204,12 @@ process {
         Write-InfoLog ("Cleaning uploaded metadata files")
         foreach ($uploadedFile in $metaDataFileUploadTokens.GetEnumerator()){
 
-            $token = [string]$uploadedFile.Value            
-            $response = DeleteUploadedFile -uri (CreateUploadUri -endpoint "/uploads/$token")
+            $token = [string]$uploadedFile.Value
+            $response = DeleteUploadedFile -uri (CreateUrl -endpoint "/$token" -Kind "Upload")
         }
     }
-    
-    
+
+
     Write-InfoLog "Total created records $totalSuccess"
     Write-InfoLog "Total failed uploads $totalFailed"
 }

--- a/AprimoHotFolderService/README.md
+++ b/AprimoHotFolderService/README.md
@@ -12,12 +12,12 @@ Prior to running the script, it needs to be configured. To that end, edit the *a
 | ---: | --- |
 | endpointUri | The uri to your MO/ADAM installation, e.g. *https://mycompanyname.aprimo.com* |
 | uploadserviceUri | The endpoint uri to the upload service, e.g. *https://mycompanyname.aprimo.com/uploads* |
-| clientId | The client-id, as created in Marketing Operations |
-| authorization | The Base-64 Encoded Authorization Code, make sure to include the prefix, e.g. *Basic [Base64 encoded string]* |
+| clientId | The Client ID of an Aprimo integration client using the Client Credentials OAuth flow |
+| clientSecret | The Client Secret of an Aprimo integration client using the Client Credentials OAuth flow |
 | logDir | The directory where the log files are written |
 | logLevel | The log level, valid values are *None*, *Error*, *Warn*, *Info*, *Debug* |
 
-For information on how to create a client-id and authorization code see [the Authorization section](https://developers.aprimo.com/marketing-operations/rest-api/authorization/#module3) of the Marketing Operations REST API [documentation](https://developers.aprimo.com/marketing-operations/rest-api/).
+For information on how to create a Client ID and Client Secret, see the [Authorization documentation](https://developers.aprimo.com/docs/OAuth2).
 
 ## Executing the script
 ```ps

--- a/AprimoHotFolderService/app.config
+++ b/AprimoHotFolderService/app.config
@@ -5,9 +5,9 @@
         <add key="endpointUri" value="" />
         <!-- The uploadserviceUri should be https://[CustomerURL].aprimo.com-->
         <add key="uploadserviceUri" value="" />
-        <!-- For instructions about generating the authorization and client-id, see: https://developers.aprimo.com/marketing-operations/rest-api/authorization/#module3 -->
-        <add key="authorization" value="" />
+        <!-- For instructions on getting a clientId and clientSecret, see the Client Credentials OAuth 2.0 documentation: https://developers.aprimo.com/docs/OAuth2 -->
         <add key="clientId" value="" />
+        <add key="clientSecret" value="" />
         <add key="logDir" value="" />
         <add key="logLevel" value="Info" />
     </appSettings>

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ Get the script from [GitHub](https://github.com/Aprimo-Connect/HotFolderUpload).
 ## Configuration
 Add the following details to the `app.config` file for the script to work:
 - **Aprimo DAM URL**
+- **Upload Service URL**
 - **Client ID**
-- **Authentication token**
+- **Client Secret**
 
 Example `app.config` file:
 ```xml
@@ -32,8 +33,8 @@ Example `app.config` file:
   <appSettings>
     <add key="endpointUri" value="https://yourcompany.dam.aprimo.com" />
     <add key="uploadserviceUri" value="https://yourcompany.aprimo.com" />
-    <add key="authorization" value="[Auth Token]" />
     <add key="clientId" value="[Client ID]" />
+    <add key="clientSecret" value="[Client Secret]" />
     <add key="logDir" value="C:\scriptlog" />
     <add key="logLevel" value="Info" />
   </appSettings>


### PR DESCRIPTION
Updates the authentication mechanism to use the OAuth Client Credentials flow and removes deprecated token-based flows.

- Refactors CreateUrl/CreateHeaders to support new Auth and Upload kinds
- Adds ValidateConfig to enforce required settings and updates Initialize-Session to fetch client credentials
- Cleans up old refresh-token functions and updates calls in upload/delete logic